### PR TITLE
css-theme-update

### DIFF
--- a/docmakers/_tests/docpage.css
+++ b/docmakers/_tests/docpage.css
@@ -118,8 +118,8 @@ mark {
 p code,
 dd code,
 .md-list code {
+  padding: 0.1em;
   border-radius: 3px;
-  padding: 0.2em 0.3em;
   background-color: #f2f2f2;
 }
 
@@ -165,6 +165,7 @@ ul {
 .md-list,
 .md-list ul {
   margin-left: 2em;
+  line-height: 1.5em;
 }
 
 .md-list li {

--- a/docmakers/_tests/docpage.css
+++ b/docmakers/_tests/docpage.css
@@ -67,8 +67,9 @@ pre {
   font-size: 14px;
   line-height: 1.3em;
   border-radius: 5px;
-  white-space: pre-wrap;
   background-color: #f2f2f2;
+  overflow-x: auto;
+  white-space: pre;
 }
 
 pre code {
@@ -104,6 +105,7 @@ em {
   color: var(--em-color);
 }
 
+/*
 mark {
   font-size: 16px;
   font-style: normal;
@@ -111,6 +113,7 @@ mark {
   color: var(--mark-color);
   background-color: white;
 }
+*/
 
 p code,
 dd code,
@@ -481,6 +484,10 @@ dd {
 }
 
 dd i {
+  color: var(--mark-color);
+}
+
+dd em {
   color: var(--ibm-blue);
 }
 

--- a/docmakers/pyreporters.py
+++ b/docmakers/pyreporters.py
@@ -29,7 +29,7 @@ def docpackage(pkgpath, docpath, mode, maxdepth=None) -> None:
     docpath : str
         Path where to place the output files.
     mode : str
-        Specifies the output format — <i>"html"</i> or <i>"md"</i>.
+        Specifies the output format — "html" or "md".
     maxdepth : int = None
         Maximum depth of nested subpackages.
         If None, all subpackages are included.

--- a/docpage/npdocs/emphase.py
+++ b/docpage/npdocs/emphase.py
@@ -38,7 +38,7 @@ class InlineEditor:
         re_with_keyword = self.RE_WITH_KEYWORD
 
         def repl_keyword(obj):
-            return "<i>" + obj.group() + "</i>"
+            return "<em>" + obj.group() + "</em>"
 
         def repl_snippet(obj):
             return re.sub(

--- a/docpage/templates/docpage.css
+++ b/docpage/templates/docpage.css
@@ -118,8 +118,8 @@ mark {
 p code,
 dd code,
 .md-list code {
+  padding: 0.1em;
   border-radius: 3px;
-  padding: 0.2em 0.3em;
   background-color: #f2f2f2;
 }
 
@@ -165,6 +165,7 @@ ul {
 .md-list,
 .md-list ul {
   margin-left: 2em;
+  line-height: 1.5em;
 }
 
 .md-list li {

--- a/docpage/templates/docpage.css
+++ b/docpage/templates/docpage.css
@@ -67,8 +67,9 @@ pre {
   font-size: 14px;
   line-height: 1.3em;
   border-radius: 5px;
-  white-space: pre-wrap;
   background-color: #f2f2f2;
+  overflow-x: auto;
+  white-space: pre;
 }
 
 pre code {
@@ -104,6 +105,7 @@ em {
   color: var(--em-color);
 }
 
+/*
 mark {
   font-size: 16px;
   font-style: normal;
@@ -111,6 +113,7 @@ mark {
   color: var(--mark-color);
   background-color: white;
 }
+*/
 
 p code,
 dd code,
@@ -481,6 +484,10 @@ dd {
 }
 
 dd i {
+  color: var(--mark-color);
+}
+
+dd em {
   color: var(--ibm-blue);
 }
 

--- a/docpage/textmd/_tests/test_textmd_emphase.py
+++ b/docpage/textmd/_tests/test_textmd_emphase.py
@@ -17,7 +17,7 @@ TEXT_MD = """
 
 TEXT_HTML = """
 <code>CODE</code>,
-<mark>&quot;MARK&quot;</mark>,
+<i>&quot;MARK&quot;</i>,
 <b>BOLD</b>,
 <em>ITALIC</em>,
 <b><em>STRONG</em></b>
@@ -36,7 +36,7 @@ class TestPatterns(unittest.TestCase):
         assert editor('`TEXT`') == '<code>TEXT</code>'
 
     def test_quotmarks(self):
-        assert editor('"TEXT"') == '<mark>&quot;TEXT&quot;</mark>'
+        assert editor('"TEXT"') == '<i>&quot;TEXT&quot;</i>'
 
     def test_asterisks_bold(self):
         assert editor('**TEXT**') == '<b>TEXT</b>'

--- a/docpage/textmd/emphase.py
+++ b/docpage/textmd/emphase.py
@@ -72,7 +72,7 @@ class InlineEditor:
 
     def translate_quotmarks(self, snippet):
         return self.edit_snippet(
-            snippet, symbol='"', start='<mark>&quot;', end='&quot;</mark>'
+            snippet, symbol='"', start='<i>&quot;', end='&quot;</i>'
         )
 
     def translate_asterisks(self, snippet):

--- a/docs/build/docpage.css
+++ b/docs/build/docpage.css
@@ -118,8 +118,8 @@ mark {
 p code,
 dd code,
 .md-list code {
+  padding: 0.1em;
   border-radius: 3px;
-  padding: 0.2em 0.3em;
   background-color: #f2f2f2;
 }
 
@@ -165,6 +165,7 @@ ul {
 .md-list,
 .md-list ul {
   margin-left: 2em;
+  line-height: 1.5em;
 }
 
 .md-list li {

--- a/docs/build/docpage.css
+++ b/docs/build/docpage.css
@@ -67,8 +67,9 @@ pre {
   font-size: 14px;
   line-height: 1.3em;
   border-radius: 5px;
-  white-space: pre-wrap;
   background-color: #f2f2f2;
+  overflow-x: auto;
+  white-space: pre;
 }
 
 pre code {
@@ -104,6 +105,7 @@ em {
   color: var(--em-color);
 }
 
+/*
 mark {
   font-size: 16px;
   font-style: normal;
@@ -111,6 +113,7 @@ mark {
   color: var(--mark-color);
   background-color: white;
 }
+*/
 
 p code,
 dd code,
@@ -481,6 +484,10 @@ dd {
 }
 
 dd i {
+  color: var(--mark-color);
+}
+
+dd em {
   color: var(--ibm-blue);
 }
 

--- a/docs/build/docspyer.html
+++ b/docs/build/docspyer.html
@@ -86,14 +86,14 @@
 <p><span class="vardef"><code>mode</code> : <em>str</em></span></p>
 
 <dl><dd>
-  Specifies the output format — <i><mark>&quot;html&quot;</mark></i> or <i><mark>&quot;md&quot;</mark></i>.
+  Specifies the output format — <i>&quot;html&quot;</i> or <i>&quot;md&quot;</i>.
 </dd></dl>
 
 <p><span class="vardef"><code>maxdepth</code> : <em>int = None</em></span></p>
 
 <dl><dd>
   Maximum depth of nested subpackages.
-  If <i>None</i>, all subpackages are included.
+  If <em>None</em>, all subpackages are included.
 </dd></dl>
 
 <div class="toc-anchor"></div><h2>docscript()</h2>
@@ -119,7 +119,7 @@
 <p><span class="vardef"><code>mode</code> : <em>str</em></span></p>
 
 <dl><dd>
-  Specifies the output format — <i><mark>&quot;html&quot;</mark></i> or <i><mark>&quot;md&quot;</mark></i>.
+  Specifies the output format — <i><i>&quot;html&quot;</i></i> or <i><i>&quot;md&quot;</i></i>.
 </dd></dl>
 
 <div class="toc-anchor"></div><h2>docsource()</h2>
@@ -145,7 +145,7 @@
 <p><span class="vardef"><code>codeblocks</code> : <em>bool</em></span></p>
 
 <dl><dd>
-  Code highlighting is activated, if <i>True</i>.
+  Code highlighting is activated, if <em>True</em>.
 </dd></dl>
 
 <div class="toc-anchor"></div><h2>builddocs()</h2>
@@ -186,13 +186,13 @@
 <p><span class="vardef"><code>codeblocks</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  Code highlighting is activated, if <i>True</i>.
+  Code highlighting is activated, if <em>True</em>.
 </dd></dl>
 
 <p><span class="vardef"><code>swaplinks</code> : <em>bool = False</em></span></p>
 
 <dl><dd>
-  If <i>True</i>, links to MD files are converted 
+  If <em>True</em>, links to MD files are converted 
   to HTML ones across the source files.
 </dd></dl>
 
@@ -253,27 +253,27 @@
 
 <dl><dd>
   Name of the modules holder. 
-  If <i>None</i>, the longest common name is used. 
+  If <em>None</em>, the longest common name is used. 
 </dd></dl>
 
 <p><span class="vardef"><code>npstyle</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  Expects numpy style docstrings, if <i>True</i>.
+  Expects numpy style docstrings, if <em>True</em>.
   Otherwise, plain text format is used.
 </dd></dl>
 
 <p><span class="vardef"><code>moddocs</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  If <i>False</i>, modules are not documented, 
+  If <em>False</em>, modules are not documented, 
   only the index file is processed.
 </dd></dl>
 
 <p><span class="vardef"><code>modrefs</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  If <i>True</i>, the modules reference is added to the index file.
+  If <em>True</em>, the modules reference is added to the index file.
 </dd></dl>
 
 <p><span class="vardef"><code>clsverbs</code> : <em>int = 0</em></span></p>
@@ -286,7 +286,7 @@
 <p><span class="vardef"><code>codeblocks</code> : <em>bool = False</em></span></p>
 
 <dl><dd>
-  Code highlighting is activated, if <i>True</i>.
+  Code highlighting is activated, if <em>True</em>.
 </dd></dl>
 
 <div class="toc-anchor"></div><h2>funcstomd()</h2>
@@ -326,7 +326,7 @@
 <p><span class="vardef"><code>npstyle</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  Expects numpy style docstrings, if <i>True</i>.
+  Expects numpy style docstrings, if <em>True</em>.
   Otherwise, plain text format is used.
 </dd></dl>
 
@@ -367,7 +367,7 @@
 <p><span class="vardef"><code>npstyle</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  Expects numpy style docstrings, if <i>True</i>.
+  Expects numpy style docstrings, if <em>True</em>.
   Otherwise, plain text format is used.
 </dd></dl>
 
@@ -382,7 +382,7 @@
 
 <dl><dd>
   Function that filters class methods.
-  If <i>None</i>, only public methods with docs are retained.
+  If <em>None</em>, only public methods with docs are retained.
 </dd></dl>
 
 <div class="toc-anchor"></div><h2>funcstable()</h2>
@@ -430,7 +430,7 @@
 
 <dl><dd>
   Function that filters class methods.
-  If <i>None</i>, only public methods with docs are retained.
+  If <em>None</em>, only public methods with docs are retained.
 </dd></dl>
 
 <p><b>Returns</b></p>

--- a/docs/sources/docspyer.md
+++ b/docs/sources/docspyer.md
@@ -32,14 +32,14 @@ Creates an overview of a python package (static analysis).
 <p><span class="vardef"><code>mode</code> : <em>str</em></span></p>
 
 <dl><dd>
-  Specifies the output format — <i><mark>&quot;html&quot;</mark></i> or <i><mark>&quot;md&quot;</mark></i>.
+  Specifies the output format — <i>&quot;html&quot;</i> or <i>&quot;md&quot;</i>.
 </dd></dl>
 
 <p><span class="vardef"><code>maxdepth</code> : <em>int = None</em></span></p>
 
 <dl><dd>
   Maximum depth of nested subpackages.
-  If <i>None</i>, all subpackages are included.
+  If <em>None</em>, all subpackages are included.
 </dd></dl>
 
 ## docscript()
@@ -65,7 +65,7 @@ Creates a report on a python script (static analysis).
 <p><span class="vardef"><code>mode</code> : <em>str</em></span></p>
 
 <dl><dd>
-  Specifies the output format — <i><mark>&quot;html&quot;</mark></i> or <i><mark>&quot;md&quot;</mark></i>.
+  Specifies the output format — <i><i>&quot;html&quot;</i></i> or <i><i>&quot;md&quot;</i></i>.
 </dd></dl>
 
 ## docsource()
@@ -91,7 +91,7 @@ Converts an MD source file to an HTML page.
 <p><span class="vardef"><code>codeblocks</code> : <em>bool</em></span></p>
 
 <dl><dd>
-  Code highlighting is activated, if <i>True</i>.
+  Code highlighting is activated, if <em>True</em>.
 </dd></dl>
 
 ## builddocs()
@@ -132,13 +132,13 @@ Assemble HTML documentation from MD source files.
 <p><span class="vardef"><code>codeblocks</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  Code highlighting is activated, if <i>True</i>.
+  Code highlighting is activated, if <em>True</em>.
 </dd></dl>
 
 <p><span class="vardef"><code>swaplinks</code> : <em>bool = False</em></span></p>
 
 <dl><dd>
-  If <i>True</i>, links to MD files are converted 
+  If <em>True</em>, links to MD files are converted 
   to HTML ones across the source files.
 </dd></dl>
 
@@ -199,27 +199,27 @@ Creates MD documentation for python modules.
 
 <dl><dd>
   Name of the modules holder. 
-  If <i>None</i>, the longest common name is used. 
+  If <em>None</em>, the longest common name is used. 
 </dd></dl>
 
 <p><span class="vardef"><code>npstyle</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  Expects numpy style docstrings, if <i>True</i>.
+  Expects numpy style docstrings, if <em>True</em>.
   Otherwise, plain text format is used.
 </dd></dl>
 
 <p><span class="vardef"><code>moddocs</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  If <i>False</i>, modules are not documented, 
+  If <em>False</em>, modules are not documented, 
   only the index file is processed.
 </dd></dl>
 
 <p><span class="vardef"><code>modrefs</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  If <i>True</i>, the modules reference is added to the index file.
+  If <em>True</em>, the modules reference is added to the index file.
 </dd></dl>
 
 <p><span class="vardef"><code>clsverbs</code> : <em>int = 0</em></span></p>
@@ -232,7 +232,7 @@ Creates MD documentation for python modules.
 <p><span class="vardef"><code>codeblocks</code> : <em>bool = False</em></span></p>
 
 <dl><dd>
-  Code highlighting is activated, if <i>True</i>.
+  Code highlighting is activated, if <em>True</em>.
 </dd></dl>
 
 ## funcstomd()
@@ -272,7 +272,7 @@ Returns documentation of functions in MD.
 <p><span class="vardef"><code>npstyle</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  Expects numpy style docstrings, if <i>True</i>.
+  Expects numpy style docstrings, if <em>True</em>.
   Otherwise, plain text format is used.
 </dd></dl>
 
@@ -313,7 +313,7 @@ Returns a class documentation in MD.
 <p><span class="vardef"><code>npstyle</code> : <em>bool = True</em></span></p>
 
 <dl><dd>
-  Expects numpy style docstrings, if <i>True</i>.
+  Expects numpy style docstrings, if <em>True</em>.
   Otherwise, plain text format is used.
 </dd></dl>
 
@@ -328,7 +328,7 @@ Returns a class documentation in MD.
 
 <dl><dd>
   Function that filters class methods.
-  If <i>None</i>, only public methods with docs are retained.
+  If <em>None</em>, only public methods with docs are retained.
 </dd></dl>
 
 ## funcstable()
@@ -376,7 +376,7 @@ Fetches methods from a class.
 
 <dl><dd>
   Function that filters class methods.
-  If <i>None</i>, only public methods with docs are retained.
+  If <em>None</em>, only public methods with docs are retained.
 </dd></dl>
 
 <b>Returns</b>


### PR DESCRIPTION
Revised MD-to-HTML rendering
- quotation marks to italic
Updated CSS template for docpage:
- colors of keywords in docstrings (--ibm-blue)
